### PR TITLE
fixed the typo

### DIFF
--- a/src/pymorize/core/cmorizer.py
+++ b/src/pymorize/core/cmorizer.py
@@ -478,20 +478,20 @@ class CMORizer:
                     filename = input_collection.files[0]
                 except IndexError:
                     break
-                model_units = rule.get("model_unit") or fc.get(filename).units
-                cmor_units = rule.data_request_variable.units
+                model_unit = rule.get("model_unit") or fc.get(filename).units
+                cmor_unit = rule.data_request_variable.units
                 cmor_variable = rule.data_request_variables.get("cmor_variable")
-                if model_units is None:
-                    if not (is_unit_scalar(cmor_units) or cmor_units == "%"):
+                if model_unit is None:
+                    if not (is_unit_scalar(cmor_unit) or cmor_unit == "%"):
                         errors.append(
                             ValueError(
-                                f"dimensionless variables must have dimensionless units ({model_units}  {cmor_units})"
+                                f"dimensionless variables must have dimensionless units ({model_unit}  {cmor_unit})"
                             )
                         )
-                if is_unit_scalar(cmor_units):
-                    if not is_unit_scalar(model_units):
+                if is_unit_scalar(cmor_unit):
+                    if not is_unit_scalar(model_unit):
                         dimless = rule.get("dimensionless_unit_mappings", {})
-                        if cmor_units not in dimless.get(cmor_variable, {}):
+                        if cmor_unit not in dimless.get(cmor_variable, {}):
                             errors.append(
                                 f"Missing mapping for dimensionless variable {cmor_variable}"
                             )

--- a/src/pymorize/core/validate.py
+++ b/src/pymorize/core/validate.py
@@ -186,7 +186,7 @@ RULES_SCHEMA = {
                     # FIXME(PG): Should cross-check with pipelines.
                     "schema": {"type": "string"},
                 },
-                "cmor_units": {"type": "string", "required": False},
+                "cmor_unit": {"type": "string", "required": False},
                 "model_unit": {"type": "string", "required": False},
                 "file_timespan": {"type": "string", "required": False},
                 "variant_label": {

--- a/src/pymorize/core/validate.py
+++ b/src/pymorize/core/validate.py
@@ -187,8 +187,7 @@ RULES_SCHEMA = {
                     "schema": {"type": "string"},
                 },
                 "cmor_units": {"type": "string", "required": False},
-                # FIXME(PS): How is it currently defined?
-                "model_units": {"type": "string", "required": False},
+                "model_unit": {"type": "string", "required": False},
                 "file_timespan": {"type": "string", "required": False},
                 "variant_label": {
                     "type": "string",


### PR DESCRIPTION
Fixed the typo. `model_unit` is used in the rest of the code base.
