### PR TITLE
feat: allows restricting of rule matchings by table id

### DIFF
--- a/src/pymorize/core/cmorizer.py
+++ b/src/pymorize/core/cmorizer.py
@@ -361,6 +361,16 @@ class CMORizer:
         for rule in self.rules:
             if len(rule.data_request_variables) == 1:
                 new_rules.append(rule)
+            # Rule has a table_id or a table_name, so it should only
+            # match that table
+            elif hasattr(rule, "table_id"):
+                for drv in rule.data_request_variables:
+                    if drv.table_name == rule.table_id:
+                        new_rules.append(rule)
+            elif hasattr(rule, "table_name"):
+                for drv in rule.data_request_variables:
+                    if drv.table_name == rule.table_name:
+                        new_rules.append(rule)
             else:
                 cloned_rules = rule.expand_drvs()
                 for rule in cloned_rules:

--- a/src/pymorize/core/cmorizer.py
+++ b/src/pymorize/core/cmorizer.py
@@ -361,20 +361,25 @@ class CMORizer:
         for rule in self.rules:
             if len(rule.data_request_variables) == 1:
                 new_rules.append(rule)
-            # Rule has a table_id or a table_name, so it should only
-            # match that table
-            elif hasattr(rule, "table_id"):
-                for drv in rule.data_request_variables:
-                    if drv.table_name == rule.table_id:
-                        new_rules.append(rule)
-            elif hasattr(rule, "table_name"):
-                for drv in rule.data_request_variables:
-                    if drv.table_name == rule.table_name:
-                        new_rules.append(rule)
             else:
                 cloned_rules = rule.expand_drvs()
                 for rule in cloned_rules:
-                    new_rules.append(rule)
+                    # Rule has a table_id or a table_name, so it should only
+                    # match that table
+                    if hasattr(rule, "table_id"):
+                        logger.info(f"Specified table_id as {rule.table_id=}")
+                        for drv in rule.data_request_variables:
+                            if drv.table_header.table_id == rule.table_id:
+                                logger.info(f"Adding rule/table combo for {drv}")
+                                new_rules.append(rule)
+                    elif hasattr(rule, "table_name"):
+                        logger.info(f"Specified table_name as {rule.table_name=}")
+                        for drv in rule.data_request_variables:
+                            if drv.table_header.table_id == rule.table_name:
+                                logger.info(f"Adding rule/table combo for {drv}")
+                                new_rules.append(rule)
+                    else:
+                        new_rules.append(rule)
         self.rules = new_rules
 
     def _rules_depluralize_drvs(self):

--- a/src/pymorize/core/cmorizer.py
+++ b/src/pymorize/core/cmorizer.py
@@ -367,15 +367,23 @@ class CMORizer:
                     # Rule has a table_id or a table_name, so it should only
                     # match that table
                     if hasattr(rule, "table_id"):
+                        if isinstance(rule.table_id, str):
+                            rule.table_id = [
+                                rule.table_id,
+                            ]
                         logger.info(f"Specified table_id as {rule.table_id=}")
                         for drv in rule.data_request_variables:
-                            if drv.table_header.table_id == rule.table_id:
+                            if drv.table_header.table_id in rule.table_id:
                                 logger.info(f"Adding rule/table combo for {drv}")
                                 new_rules.append(rule)
                     elif hasattr(rule, "table_name"):
+                        if isinstance(rule.table_name, str):
+                            rule.table_name = [
+                                rule.table_name,
+                            ]
                         logger.info(f"Specified table_name as {rule.table_name=}")
                         for drv in rule.data_request_variables:
-                            if drv.table_header.table_id == rule.table_name:
+                            if drv.table_header.table_id in rule.table_name:
                                 logger.info(f"Adding rule/table combo for {drv}")
                                 new_rules.append(rule)
                     else:


### PR DESCRIPTION
## Blockers
+ [x] #145 

## Issues
* Closes #136 

## Copilot Summary

This pull request introduces a refinement in the `_rules_expand_drvs` method within the `src/pymorize/core/cmorizer.py` file. The change ensures that rules with specific `table_id` or `table_name` attributes are correctly matched to their respective tables during the rule expansion process.

### Refinement of rule matching logic:

* Updated `_rules_expand_drvs` to handle rules with `table_id` or `table_name` attributes by checking if `data_request_variables` match the specified table. This ensures proper filtering and inclusion of relevant rules.