### PR TITLE
file-timespans

### DIFF
--- a/src/pymor/std_lib/files.py
+++ b/src/pymor/std_lib/files.py
@@ -44,7 +44,7 @@ import pandas as pd
 import xarray as xr
 from xarray.core.utils import is_scalar
 
-from .dataset_helpers import get_time_label, has_time_axis, needs_resampling
+from .dataset_helpers import get_time_label, has_time_axis
 
 
 def _filename_time_range(ds, rule) -> str:
@@ -140,6 +140,88 @@ def create_filepath(ds, rule):
     return filepath
 
 
+def get_offset(rule):
+    """convert offset defined on the rule to a timedelta."""
+    offset = rule.get("adjust_timestamp", None)
+    if offset is not None:
+        offset_presets = {
+            "first": 0,
+            "start": 0,
+            "last": 1,
+            "end": 1,
+            "mid": 0.5,
+            "middle": 0.5,
+        }
+        offset = offset_presets.get(offset, offset)
+        try:
+            # expect offset to a literal string. Example: "14D"
+            offset = pd.Timedelta(offset)
+        except ValueError:
+            # offset is a float value scaled by the approx_interval
+            approx_interval = float(rule.data_request_variable.table_header.approx_interval)
+            dt = pd.Timedelta(approx_interval, unit="d")
+            offset = dt * float(offset)
+    return offset
+
+
+def file_timespan_tail(rule):
+    """Grab the last timestamp in each file and return them as a list.
+    Also account for offset (if any) defined on the rule"""
+    times = []
+    options = {"decode_times": xr.coders.CFDatetimeCoder(use_cftime=True)}
+    for _input in rule.inputs:
+        for f in sorted(_input.files):
+            ds = xr.open_dataset(str(f), **options)
+            times.append(ds.time.values[-1])
+    offset = get_offset(rule)
+    if offset is not None:
+        times = xr.CFTimeIndex(times) + offset
+    return times
+
+
+def split_data_timespan(ds, rule):
+    """
+    Splits the dataset into chunks based on the time axis as defined in the source files.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The dataset to split.
+    rule : Rule
+        The rule object containing information for generating the
+        filepath.
+
+    Returns
+    -------
+    list
+        A list of datasets, each containing a chunk of the original dataset.
+    """
+    from collections import deque
+
+    time_cuts = deque(file_timespan_tail(rule))
+    resampled_times = deque(ds.time.values)
+    result = []
+    while time_cuts:
+        cutoff = time_cuts.popleft()
+        tmp = []
+        while True:
+            try:
+                ts = resampled_times.popleft()
+            except IndexError:
+                break
+            if ts <= cutoff:
+                tmp.append(ts)
+            else:
+                resampled_times.appendleft(ts)
+                result.append(tmp)
+                break
+    data_chunks = []
+    for timespan in result:
+        da = ds.sel(time=slice(timespan[0], timespan[-1]))
+        data_chunks.append(da)
+    return data_chunks
+
+
 def save_dataset(da: xr.DataArray, rule):
     """
     Save dataset to one or more files.
@@ -215,24 +297,47 @@ def save_dataset(da: xr.DataArray, rule):
         time_encoding["_FillValue"] = None
 
     file_timespan = getattr(rule, "file_timespan", None)
-    if not needs_resampling(da, file_timespan):
-        filepath = create_filepath(da, rule)
-        return da.to_netcdf(
-            filepath,
-            mode="w",
-            format="NETCDF4",
+    if file_timespan is None:
+        paths = []
+        datasets = split_data_timespan(da, rule)
+        for group_ds in datasets:
+            paths.append(create_filepath(group_ds, rule))
+        return xr.save_mfdataset(
+            datasets,
+            paths,
             encoding={time_label: time_encoding},
             **extra_kwargs,
         )
-    groups = da.resample(time=file_timespan)
-    paths = []
-    datasets = []
-    for group_name, group_ds in groups:
-        paths.append(create_filepath(group_ds, rule))
-        datasets.append(group_ds)
-    return xr.save_mfdataset(
-        datasets,
-        paths,
-        encoding={time_label: time_encoding},
-        **extra_kwargs,
-    )
+    else:
+        file_timespan_as_offset = pd.tseries.frequencies.to_offset(file_timespan)
+        file_timespan_as_dt = pd.Timestamp.now() + file_timespan_as_offset - pd.Timestamp.now()
+        approx_interval = float(rule.data_request_variable.table_header.approx_interval)
+        dt = pd.Timedelta(approx_interval, unit="d")
+        if file_timespan_as_dt < dt:
+            logger.warning(
+                f"file_timespan {file_timespan_as_dt} is smaller than approx_interval {dt}"
+                "falling back to timespan as defined in the source file"
+            )
+            paths = []
+            datasets = split_data_timespan(da, rule)
+            for group_ds in datasets:
+                paths.append(create_filepath(group_ds, rule))
+            return xr.save_mfdataset(
+                datasets,
+                paths,
+                encoding={time_label: time_encoding},
+                **extra_kwargs,
+            )
+        else:
+            groups = da.resample(time=file_timespan)
+            paths = []
+            datasets = []
+            for group_name, group_ds in groups:
+                paths.append(create_filepath(group_ds, rule))
+                datasets.append(group_ds)
+            return xr.save_mfdataset(
+                datasets,
+                paths,
+                encoding={time_label: time_encoding},
+                **extra_kwargs,
+        )

--- a/src/pymor/std_lib/timeaverage.py
+++ b/src/pymor/std_lib/timeaverage.py
@@ -33,55 +33,12 @@ _IGNORED_CELL_METHODS : list
 
 """
 
-import itertools
 import re
 
 import pandas as pd
 import xarray as xr
 
 from ..core.logging import logger
-
-
-def _split_by_chunks(dataset: xr.DataArray):
-    """
-    Split a large dataset into sub-datasets for each chunk.
-
-    This function is useful for handling large datasets that cannot fit into memory all at once.
-    It yields a tuple containing the selection dictionary and the corresponding sub-dataset.
-
-    Parameters
-    ----------
-    dataset : xr.DataArray
-        The input dataset to be chunked. It can be either an xarray Dataset or DataArray.
-
-    Yields
-    ------
-    tuple
-        A tuple containing the selection dictionary and the corresponding sub-dataset.
-
-    References
-    ----------
-    .. [1] https://github.com/pydata/xarray/issues/1093#issuecomment-259213382
-    """
-    chunk_slices = {}
-    logger.info(f"{dataset.chunks=}")
-    if not dataset.chunks:
-        raise ValueError("Dataset has no chunks")
-    if isinstance(dataset, xr.Dataset):
-        chunker = dataset.chunks
-    elif isinstance(dataset, xr.DataArray):
-        chunker = {dim: chunk for dim, chunk in zip(dataset.dims, dataset.chunks)}
-    for dim, chunks in chunker.items():
-        slices = []
-        start = 0
-        for chunk in chunks:
-            stop = start + chunk
-            slices.append(slice(start, stop))
-            start = stop
-        chunk_slices[dim] = slices
-    for slices in itertools.product(*chunk_slices.values()):
-        selection = dict(zip(chunk_slices.keys(), slices))
-        yield (selection, dataset[selection])
 
 
 def _get_time_method(frequency: str) -> str:
@@ -176,50 +133,6 @@ def _frequency_from_approx_interval(interval: str):
     return "".join(result)
 
 
-def _compute_file_timespan(da: xr.DataArray):
-    """
-    Compute the timespan of a given data array.
-
-    This function splits the data array into chunks and computes the timespan of each chunk.
-    The timespan of a chunk is defined as the difference between the last and the first time point in the chunk.
-    The function returns the maximum timespan among all chunks.
-
-    Parameters
-    ----------
-    da : xr.DataArray
-        The data array to compute the timespan for.
-
-    Returns
-    -------
-    int
-        The maximum timespan among all chunks of the data array.
-
-    """
-    if "time" not in da.dims:
-        raise ValueError("missing the 'time' dimension")
-    # Check if "time" dimension is empty
-    if da.time.size == 0:
-        raise ValueError("no time values in this chunk")
-    chunks = _split_by_chunks(da)
-    tmp_file_timespan = []
-    for i in range(3):
-        try:
-            subset_name, subset = next(chunks)
-        except StopIteration:
-            break
-        else:
-            logger.info(f"{subset_name=}")
-            logger.info(f"{subset.time.data[-1]=}")
-            logger.info(f"{subset.time.data[0]=}")
-            tmp_file_timespan.append(
-                pd.Timedelta(subset.time.data[-1] - subset.time.data[0]).days
-            )
-    if not tmp_file_timespan:
-        raise ValueError("No chunks found")
-    file_timespan = max(tmp_file_timespan)
-    return file_timespan
-
-
 def timeavg(da: xr.DataArray, rule):
     """
     Time averages data with respect to time-method (mean/climatology/instant.)
@@ -251,10 +164,6 @@ def timeavg(da: xr.DataArray, rule):
     xr.DataArray
         The time averaged data array.
     """
-    file_timespan = _compute_file_timespan(da)
-    rule.file_timespan = getattr(rule, "file_timespan", None) or pd.Timedelta(
-        file_timespan, unit="D"
-    )
     drv = rule.data_request_variable
     approx_interval = drv.table_header.approx_interval
     frequency_str = _frequency_from_approx_interval(approx_interval)


### PR DESCRIPTION
File-timespan feature allows the set the number of timestamps per file in the output data.

In this implementation, the original file-timespan is read from the source files instead of intertwine code with `timeavg` function. If the `file_timespan` option is provided in the yaml file, then it produces the output accordingly where ever applicable.

Here is a tested output from the workshop material for reference:

```
file-timespan: None, table_id: None. # same number of timesteps per file as defined in the source files.

  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300101-300112.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300201-300212.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300301-300312.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300401-300412.nc
  fgco2_Oyr_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_3001-3001.nc
  fgco2_Oyr_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_3002-3002.nc
  fgco2_Oyr_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_3003-3003.nc
  fgco2_Oyr_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_3004-3004.nc

file-timespan: 2YS, table_id: Omon

  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300101-300212.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300301-300412.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300501-300512.nc

file-timespan: 6MS, table_id: Omon

  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300101-300106.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300107-300112.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300201-300206.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300207-300212.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300301-300306.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300307-300312.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300401-300406.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300407-300412.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300501-300506.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300507-300512.nc

file-timespan: 6MS, table_id: None <= {Omon, Oyr}. # the 6MS is not applicable to yearly data, fallback to as defined in the sourcefiles.

  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300101-300106.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300107-300112.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300201-300206.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300207-300212.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300301-300306.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300307-300312.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300401-300406.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300407-300412.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300501-300506.nc
  fgco2_Omon_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_300507-300512.nc
  fgco2_Oyr_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_3001-3001.nc
  fgco2_Oyr_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_3002-3002.nc
  fgco2_Oyr_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_3003-3003.nc
  fgco2_Oyr_AWI-AWI-CM-1-1-HR_piControl_r1i1p1f1_gn_3004-3004.nc
```